### PR TITLE
122 nth allow individual proposed classes to be deleted

### DIFF
--- a/frontend/src/class-management-page/ScheduleView.tsx
+++ b/frontend/src/class-management-page/ScheduleView.tsx
@@ -153,13 +153,13 @@ const ScheduleView = () => {
     }
   };
 
-  const deleteMessage = (message: string) =>
-    dayAbbreviation(message) + " " + message + " verwijderen?";
+  const deleteMessage = (classDto: ScheduledClassDtoWithoutAttendance) =>
+    getFormattedClass(classDto) + " verwijderen?";
 
   const handleDeleteProposedClass = (
     proposedClass: ScheduledClassDtoWithoutAttendance
   ) => {
-    if (confirm(deleteMessage(proposedClass.dateAsString))) {
+    if (confirm(deleteMessage(proposedClass))) {
       const filteredClasses = proposedClasses.filter(
         (sc) => sc.dateAsString !== proposedClass.dateAsString
       );
@@ -168,12 +168,18 @@ const ScheduleView = () => {
     }
   };
 
-  const dayAbbreviation = (d: string) =>
-    new Date(d).toLocaleString("nl-NL", { weekday: "long" }).substring(0, 2);
+  const getFormattedClass = (classDto: ScheduledClassDtoWithoutAttendance) => {
+    const dayAbbreviation = new Date(classDto.dateAsString)
+      .toLocaleString("nl-NL", { weekday: "long" })
+      .substring(0, 2);
+    const teacherName = teachers.find((x) => x.id === classDto.teacherId)?.name;
 
-  const showClassesToAdd = proposedClasses.map((value) => (
+    return dayAbbreviation + " " + classDto.dateAsString + " " + teacherName;
+  };
+
+  const showProposedClasses = proposedClasses.map((value) => (
     <li key={value.dateAsString}>
-      {dayAbbreviation(value.dateAsString)} {value.dateAsString}
+      {getFormattedClass(value)};
       <button
         value={value.dateAsString}
         onClick={() => handleDeleteProposedClass(value)}
@@ -220,7 +226,7 @@ const ScheduleView = () => {
   const handleDeleteScheduledClass = (
     scheduledClass: ScheduledClassDtoWithoutAttendance
   ) => {
-    if (confirm(deleteMessage(scheduledClass.dateAsString))) {
+    if (confirm(deleteMessage(scheduledClass))) {
       axios
         .delete(
           `${BASE_URL}/scheduled-classes/${scheduledClass.groupId}/${scheduledClass.dateAsString}`,
@@ -246,13 +252,13 @@ const ScheduleView = () => {
     }
   };
 
-  const showScheduledClasses = scheduledClasses.map((value) => (
-    <li key={value.dateAsString}>
-      {dayAbbreviation(value.dateAsString)} {value.dateAsString}
+  const showScheduledClasses = scheduledClasses.map((classDto) => (
+    <li key={classDto.dateAsString}>
+      {getFormattedClass(classDto)}
       <button
-        value={value.dateAsString}
-        onClick={() => handleDeleteScheduledClass(value)}
-        hidden={new Date(value.dateAsString) <= new Date()}
+        value={classDto.dateAsString}
+        onClick={() => handleDeleteScheduledClass(classDto)}
+        hidden={new Date(classDto.dateAsString) <= new Date()}
       >
         X
       </button>
@@ -341,7 +347,9 @@ const ScheduleView = () => {
                   </div>
 
                   <div>
-                    <ul className="striping no-bullets">{showClassesToAdd}</ul>
+                    <ul className="striping no-bullets">
+                      {showProposedClasses}
+                    </ul>
                   </div>
 
                   <hr />


### PR DESCRIPTION
I've reused parts of "handleDeleteScheduledClass" line 217.

I don't think I can extract the shared code between that and "handleDeleteProposedClass" implementations to private methods?

EW: In theory, you can; in practice, since you need to pass different React states, it would be too fiddly to be worth it.
